### PR TITLE
fix error with extendable 'methods' not being added to instance

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -99,7 +99,7 @@ Model.init = function (collection, properties, options) {
         StereoType.super_.call(this, collection, properties);
         instance = instance || {};
         _.merge(this, instance);
-        _.merge(this, this.methods);
+        _.merge(this, options.methods);
     }
 
     util.inherits(StereoType, Model);


### PR DESCRIPTION
The diff should be self-explanatory. I think this was just a typo.

I'm not able to use the statics option in any useful way, as all I have access to inside a 'static' function is the constructor Function itself, is there some way I can use static to access things like this.properties? (From my model, but before I've instantiated a new instance of the model)
